### PR TITLE
Archive button typo

### DIFF
--- a/app/src/components/ExamDrawer.js
+++ b/app/src/components/ExamDrawer.js
@@ -155,7 +155,7 @@ export default function ExamDrawer({isAdmin, open, setOpen, exam}) {
 						loading={loading}
 						colorPalette='green'
 					>
-						<LuArchive/> Archived
+						<LuArchive/> Archive
 					</Button>
 				</ConfirmDialog>
 			}


### PR DESCRIPTION
This pull request includes a minor text change in the `ExamDrawer` component.
The button label was updated from "Archived" to "Archive" for consistency or clarity.