### PR TITLE
fix: invert condition for API_BEARER_TOKEN check

### DIFF
--- a/api/middlewares/isService.js
+++ b/api/middlewares/isService.js
@@ -4,7 +4,7 @@ const SECRET = process.env.API_BEARER_TOKEN;
 
 module.exports = function isService(req, res, next) {
 	try {
-		if (SECRET) {
+		if (!SECRET) {
 			return res.status(503).send({ error: 'Service Unavailable: API_BEARER_TOKEN not configured' });
 		}
 


### PR DESCRIPTION
This pull request corrects the logic in the `isService` middleware to properly handle the case when the `API_BEARER_TOKEN` environment variable is not set. Now, if the secret is missing, the middleware will return a 503 error as intended.

- Bug fix:
  * Corrected the conditional check in `isService.js` so that a 503 error is returned only when `API_BEARER_TOKEN` is not configured.